### PR TITLE
IME: 전각문자 지원

### DIFF
--- a/src/btnext.cpp
+++ b/src/btnext.cpp
@@ -274,12 +274,10 @@ CLangBarItemShapeButton::OnClick (
 	if (!lpIMC)
 		return S_OK;
 
-	if (!ImmGetOpenStatus(hIMC))
-	{
-		ImmUnlockIMC(hIMC);
-		return	S_OK ;
-	}
-	//	ImmSetOpenStatus (hIMC, TRUE) ;
+	BOOL fOpen = ImmGetOpenStatus(hIMC);
+	if (!fOpen)
+		ImmSetOpenStatus(hIMC, TRUE);
+
 	if (ImmGetConversionStatus (hIMC, &dwConversion, &dwSentense))
 	{
 		if (dwConversion & IME_CMODE_FULLSHAPE)
@@ -288,6 +286,9 @@ CLangBarItemShapeButton::OnClick (
 			dwConversion |= IME_CMODE_FULLSHAPE;
 		ImmSetConversionStatus (hIMC, dwConversion, 0) ;
 	}
+	if (!fOpen)
+                ImmSetOpenStatus(hIMC, FALSE);
+
 	ImmUnlockIMC(hIMC);
 	UpdateLanguageBar () ;
 #endif
@@ -376,17 +377,13 @@ CLangBarItemShapeButton::GetIcon (
 	if (!lpIMC)
 		goto Skip;
 
-	if (ImmGetOpenStatus (hIMC)) {
-		if (ImmGetConversionStatus (hIMC, &dwConversion, &dwSentence)) {
-			if (dwConversion & IME_CMODE_FULLSHAPE){
-				str	= TEXT ("INDIC_FULL") ;
-			} else {
-				str	= TEXT ("INDIC_HALF") ;
-			}
-		}
+	if (lpIMC->fdwConversion & IME_CMODE_FULLSHAPE)
+	{
+		str = TEXT("INDIC_FULL");
 	} else {
-		str	= TEXT ("INDIC_HALF") ;
+		str = TEXT("INDIC_HALF");
 	}
+
 	ImmUnlockIMC(hIMC);
 Skip:
 	if (str == NULL) {

--- a/src/dic.c
+++ b/src/dic.c
@@ -1275,7 +1275,30 @@ ac_exit:
 }
 
 #endif
-
+/**********************************************************************/
+/*                                                                    */
+/* ConvJunja()                                                        */
+/*                                                                    */
+/* convert character to Double-Width char                             */
+/*                                                                    */
+/**********************************************************************/
+DWORD PASCAL ConvJunja(DWORD code, WORD mode)
+{
+    DWORD dw = 0;
+    if (code == TEXT('\\'))
+    {
+        dw = 0xFFE6;
+    }
+    else if (code < '!' || code > '~')
+    {
+        return 0;
+    }
+    else
+    {
+        dw = code - '!' + 1 + 0xFF00 /* FULLWIDTH base code point */;
+    }
+    return dw;
+}
 
 /**********************************************************************/
 /*                                                                    */
@@ -2077,6 +2100,7 @@ CONST LPBYTE lpbKeyState;
             fdwConversion = lpIMC->fdwConversion;
             ImmUnlockIMC(hIMC);
             if (IsCompStr(hIMC) &&
+                    IsCandidate(lpIMC) &&
                     (fdwConversion & IME_CMODE_FULLSHAPE) &&
                     (fdwConversion & IME_CMODE_NATIVE)) {
                 MakeResultString(hIMC,TRUE);

--- a/src/hansub.c
+++ b/src/hansub.c
@@ -341,6 +341,16 @@ CONST LPBYTE lpbKeyState;
     if ( (!hkey || (hkey >= TEXT('!') && hkey <= TEXT('~')) )
 	    && !IsCompStr(hIMC)) {
 	// 이 경우 마지막 입력받은 ascii문자를 그대로 내뱉는다.
+
+        // 전자 입력 모드일 경우 전자로 변환
+        if ((fdwConversion & IME_CMODE_FULLSHAPE))
+        {
+            DWORD ch = ConvJunja(hkey, 0);
+            MyDebugPrint((TEXT("JUNJA Vkey: %lx => %x\r\n"), hkey, ch));
+            if (ch != 0)
+                hkey = ch;
+        }
+
 	PostMessage(lpIMC->hWnd,WM_CHAR,hkey,lParam);
 
         ImmUnlockIMC(hIMC);
@@ -679,6 +689,15 @@ CONST LPBYTE lpbKeyState;
 		lpchText = GETLPCOMPSTR(lpCompStr);
 		lpstr = lpchText;
 	    }
+
+            // 전자 입력 모드일 경우 전자로 변환
+            if ((fdwConversion & IME_CMODE_FULLSHAPE))
+            {
+                DWORD ch = ConvJunja(hkey, 0);
+                MyDebugPrint((TEXT("JUNJA Vkey: %lx => %x\r\n"), hkey, ch));
+                if (ch != 0)
+                    code = (WORD) hkey = ch;
+            }
 
 	    /* */
 	    /* XXX how to fix EditPlus problem ? */

--- a/src/saenaru.h
+++ b/src/saenaru.h
@@ -444,6 +444,7 @@ void PASCAL FlushText();
 void PASCAL RevertText(HIMC hIMC);
 
 void PASCAL AddChar(HIMC,WORD);
+DWORD PASCAL ConvJunja(DWORD, WORD);
 
 BOOL PASCAL ConvHanja(HIMC, int, int);
 BOOL WINAPI MakeResultString(HIMC,BOOL);


### PR DESCRIPTION
IME 언어바 아이콘만 있고 기능은 작동하지 않던 전각/반각 기능을 살립니다.
M$ 윈도우에서 여전히 지원하고 있는 기능이기도 합니다.

기존 IME와 다른 점은, 공백(`SPACE`)는 변환하지 않고 그대로 둡니다.