### PR TITLE
REGDLL with the 64bit bin.

### DIFF
--- a/setup/saenaru.nsi
+++ b/setup/saenaru.nsi
@@ -157,15 +157,13 @@ Section "새나루 입력기" SecBody
   Rename /REBOOTOK $3 $SYSDIR\saenaru.ime
   SaenaruDone:
 
-  #File "${DDKBUILDDIR}\SaenaruTip.dll"
-  #IfErrors 0 SaenaruTipDone
+  File "${DDKBUILDDIR}\SaenaruTip.dll"
+  IfErrors 0 SaenaruTipDone
 
-  #GetTempFileName $3
-  #File /oname=$3 "${DDKBUILDDIR}\SaenaruTip.dll"
-  #Rename /REBOOTOK $3 $SYSDIR\SaenaruTip.dll
-  #SaenaruTipDone:
-
-  !insertmacro InstallLib REGDLL NOTSHARED REBOOT_PROTECTED "${DDKBUILDDIR}\SaenaruTip.dll" "$SYSDIR\SaenaruTip.dll" $SYSDIR
+  GetTempFileName $3
+  File /oname=$3 "${DDKBUILDDIR}\SaenaruTip.dll"
+  Rename /REBOOTOK $3 $SYSDIR\SaenaruTip.dll
+  SaenaruTipDone:
 
   File "${DVBUILDDIR}\kbddvk.dll"
   IfErrors 0 kbddvkDone
@@ -190,13 +188,7 @@ Section "새나루 입력기" SecBody
     Rename /REBOOTOK $3 $SYSDIR\saenaru.ime
     Saenaru64Done:
 
-    File "${DDK64BUILDDIR}\SaenaruTip.dll"
-    IfErrors 0 SaenaruTip64Done
-
-    GetTempFileName $3
-    File /oname=$3 "${DDK64BUILDDIR}\SaenaruTip.dll"
-    Rename /REBOOTOK $3 $SYSDIR\SaenaruTip.dll
-    SaenaruTip64Done:
+    !insertmacro InstallLib REGDLL NOTSHARED REBOOT_PROTECTED "${DDK64BUILDDIR}\SaenaruTip.dll" "$SYSDIR\SaenaruTip.dll" $SYSDIR
 
     File "${DV64BUILDDIR}\kbddvk.dll"
     IfErrors 0 kbddvk64Done


### PR DESCRIPTION
윈도우 11에서 regsvr32에 의해 등록되는 레지스트리 문자열이 깨지는 문제 수정 (윈도우 10에서는 정상인데...)